### PR TITLE
Send help text on invalid DM

### DIFF
--- a/ordersbot.py
+++ b/ordersbot.py
@@ -146,6 +146,11 @@ async def on_message(message):
         is_match = re.findall(matcher, message.content, re.IGNORECASE + re.MULTILINE)
         if len(is_match):
             await fn()
+            return
+
+    # If user sends invalid command to bot, send help text.
+    if message.channel.type == discord.ChannelType.private:
+      return await _help()
 
 if __name__ == "__main__":
     import logging


### PR DESCRIPTION
If a user does not know how to interface with the bot, sending the bot any (non-command) DM will cause the bot to respond with the help text.